### PR TITLE
Fixed handling of target_args in windows implementation

### DIFF
--- a/libfuzzer-dotnet-windows.cc
+++ b/libfuzzer-dotnet-windows.cc
@@ -175,12 +175,16 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int *argc, char ***argv)
     }
     if (target_arg)
     {
-        char *temp_target = new char[strlen(target_path) + strlen(target_arg) + 1];
+        char *temp_target = new char[strlen(target_path) + 1 + strlen(target_arg) + 1];
         strcpy(temp_target, target_path);
-        strcpy(temp_target + strlen(target_path), target_arg);
+        temp_target[strlen(target_path)] = ' ';
+        strcpy(temp_target + strlen(target_path) + 1, target_arg);
         target_for_process = temp_target;
     }
-    target_for_process = target_path;
+    else
+    {
+        target_for_process = target_path;
+    }
     PROCESS_INFORMATION pi;
     STARTUPINFO si;
     ZeroMemory(&si, sizeof(si));


### PR DESCRIPTION
Fixed two problems in https://github.com/Metalnem/libfuzzer-dotnet/blob/55d84f84b3540c864371e855c2a5ecb728865d97/libfuzzer-dotnet-windows.cc#L176-L183

* if `target_arg` is given is was overwritten in L183
* in building the string together there was no space between `target_path` and `target_args`, so an non-existing exe would have been called