### PR TITLE
Add `.clang-format` and apply

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Microsoft
+IndentWidth: 4
+UseCRLF: false
+ColumnLimit: 0

--- a/libfuzzer-dotnet.cc
+++ b/libfuzzer-dotnet.cc
@@ -38,167 +38,167 @@ static pid_t child_pid;
 
 static void die(const char *msg)
 {
-	printf("%s\n", msg);
-	exit(1);
+    printf("%s\n", msg);
+    exit(1);
 }
 
 static void die_sys(const char *msg)
 {
-	printf("%s: %s\n", msg, strerror(errno));
-	exit(1);
+    printf("%s: %s\n", msg, strerror(errno));
+    exit(1);
 }
 
 static void remove_shm()
 {
-	shmctl(shm_id, IPC_RMID, NULL);
+    shmctl(shm_id, IPC_RMID, NULL);
 }
 
 // Read the flag value from the single command line parameter. For example,
 // read_flag_value("--target_path=binary", "--target-path") will return "binary".
 static const char *read_flag_value(const char *param, const char *name)
 {
-	size_t len = strlen(name);
+    size_t len = strlen(name);
 
-	if (strstr(param, name) == param && param[len] == '=' && param[len + 1])
-	{
-		return &param[len + 1];
-	}
+    if (strstr(param, name) == param && param[len] == '=' && param[len + 1])
+    {
+        return &param[len + 1];
+    }
 
-	return NULL;
+    return NULL;
 }
 
 // Read target_path (the path to .NET executable) and target_arg (optional command
 // line argument that can be passed to .NET executable) from the command line parameters.
 static void parse_flags(int argc, char **argv)
 {
-	for (int i = 0; i < argc; ++i)
-	{
-		char *param = argv[i];
+    for (int i = 0; i < argc; ++i)
+    {
+        char *param = argv[i];
 
-		if (!target_path)
-		{
-			target_path = read_flag_value(param, target_path_name);
-		}
+        if (!target_path)
+        {
+            target_path = read_flag_value(param, target_path_name);
+        }
 
-		if (!target_arg)
-		{
-			target_arg = read_flag_value(param, target_arg_name);
-		}
-	}
+        if (!target_arg)
+        {
+            target_arg = read_flag_value(param, target_arg_name);
+        }
+    }
 }
 
 // Start the .NET child process and initialize two pipes and one shared
 // memory segment for the communication between the parent and the child.
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-	parse_flags(*argc, *argv);
+    parse_flags(*argc, *argv);
 
-	if (!target_path)
-	{
-		die("You must specify the target path by using the --target_path command line flag.");
-	}
+    if (!target_path)
+    {
+        die("You must specify the target path by using the --target_path command line flag.");
+    }
 
-	int ctl_pipe[2];
-	int st_pipe[2];
+    int ctl_pipe[2];
+    int st_pipe[2];
 
-	if (pipe(ctl_pipe) || pipe(st_pipe))
-	{
-		die_sys("pipe() failed");
-	}
+    if (pipe(ctl_pipe) || pipe(st_pipe))
+    {
+        die_sys("pipe() failed");
+    }
 
-	shm_id = shmget(IPC_PRIVATE, MAP_SIZE + DATA_SIZE, IPC_CREAT | IPC_EXCL | 0600);
+    shm_id = shmget(IPC_PRIVATE, MAP_SIZE + DATA_SIZE, IPC_CREAT | IPC_EXCL | 0600);
 
-	if (shm_id < 0)
-	{
-		die_sys("shmget() failed");
-	}
+    if (shm_id < 0)
+    {
+        die_sys("shmget() failed");
+    }
 
-	atexit(remove_shm);
+    atexit(remove_shm);
 
-	trace_bits = static_cast<uint8_t *>(shmat(shm_id, NULL, 0));
+    trace_bits = static_cast<uint8_t *>(shmat(shm_id, NULL, 0));
 
-	if (trace_bits == (void *)-1)
-	{
-		die_sys("shmat() failed");
-	}
+    if (trace_bits == (void *)-1)
+    {
+        die_sys("shmat() failed");
+    }
 
-	child_pid = fork();
+    child_pid = fork();
 
-	if (child_pid < 0)
-	{
-		die_sys("fork() failed");
-	}
+    if (child_pid < 0)
+    {
+        die_sys("fork() failed");
+    }
 
-	if (!child_pid)
-	{
-		if (dup2(ctl_pipe[0], CTL_FD) < 0 || dup2(st_pipe[1], ST_FD) < 0)
-		{
-			die_sys("dup() failed");
-		}
+    if (!child_pid)
+    {
+        if (dup2(ctl_pipe[0], CTL_FD) < 0 || dup2(st_pipe[1], ST_FD) < 0)
+        {
+            die_sys("dup() failed");
+        }
 
-		close(ctl_pipe[0]);
-		close(ctl_pipe[1]);
-		close(st_pipe[0]);
-		close(st_pipe[1]);
+        close(ctl_pipe[0]);
+        close(ctl_pipe[1]);
+        close(st_pipe[0]);
+        close(st_pipe[1]);
 
-		char shm_str[12];
-		sprintf(shm_str, "%d", shm_id);
+        char shm_str[12];
+        sprintf(shm_str, "%d", shm_id);
 
-		if (setenv(SHM_ID_VAR, shm_str, 1))
-		{
-			die_sys("setenv() failed setting shared memory ID");
-		}
+        if (setenv(SHM_ID_VAR, shm_str, 1))
+        {
+            die_sys("setenv() failed setting shared memory ID");
+        }
 
-		if (setenv(CTL_FD_VAR, STR(CTL_FD), 1))
-		{
-			die_sys("setenv() failed setting control pipe ID");
-		}
+        if (setenv(CTL_FD_VAR, STR(CTL_FD), 1))
+        {
+            die_sys("setenv() failed setting control pipe ID");
+        }
 
-		if (setenv(ST_FD_VAR, STR(ST_FD), 1))
-		{
-			die_sys("setenv() failed setting status pipe ID");
-		}
+        if (setenv(ST_FD_VAR, STR(ST_FD), 1))
+        {
+            die_sys("setenv() failed setting status pipe ID");
+        }
 
-		if (target_arg)
-		{
-			execlp(target_path, "", target_arg, NULL);
-		}
-		else
-		{
-			execlp(target_path, "", NULL);
-		}
+        if (target_arg)
+        {
+            execlp(target_path, "", target_arg, NULL);
+        }
+        else
+        {
+            execlp(target_path, "", NULL);
+        }
 
-		die_sys("execlp() failed");
-	}
-	else
-	{
-		close(ctl_pipe[0]);
-		close(st_pipe[1]);
+        die_sys("execlp() failed");
+    }
+    else
+    {
+        close(ctl_pipe[0]);
+        close(st_pipe[1]);
 
-		ctl_fd = ctl_pipe[1];
-		st_fd = st_pipe[0];
+        ctl_fd = ctl_pipe[1];
+        st_fd = st_pipe[0];
 
-		ssize_t result;
-		int32_t status;
+        ssize_t result;
+        int32_t status;
 
-		while ((result = read(st_fd, &status, LEN_FLD_SIZE)) == -1 && errno == EINTR)
-		{
-			continue;
-		}
+        while ((result = read(st_fd, &status, LEN_FLD_SIZE)) == -1 && errno == EINTR)
+        {
+            continue;
+        }
 
-		if (result == -1)
-		{
-			die_sys("read() failed");
-		}
+        if (result == -1)
+        {
+            die_sys("read() failed");
+        }
 
-		if (result != LEN_FLD_SIZE)
-		{
-			printf("short read: expected %d bytes, got %zd bytes\n", LEN_FLD_SIZE, result);
-			exit(1);
-		}
-	}
+        if (result != LEN_FLD_SIZE)
+        {
+            printf("short read: expected %d bytes, got %zd bytes\n", LEN_FLD_SIZE, result);
+            exit(1);
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 // Fuzz the data by writing it to the shared memory segment, sending
@@ -207,61 +207,61 @@ extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 // the status of the executed operation.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-	if (size > DATA_SIZE)
-	{
-		die("Size of the input data must not exceed 1 MiB.");
-	}
+    if (size > DATA_SIZE)
+    {
+        die("Size of the input data must not exceed 1 MiB.");
+    }
 
-	memset(trace_bits, 0, MAP_SIZE);
-	memcpy(trace_bits + MAP_SIZE, data, size);
+    memset(trace_bits, 0, MAP_SIZE);
+    memcpy(trace_bits + MAP_SIZE, data, size);
 
-	ssize_t result;
+    ssize_t result;
 
-	while ((result = write(ctl_fd, &size, LEN_FLD_SIZE)) == -1 && errno == EINTR)
-	{
-		continue;
-	}
+    while ((result = write(ctl_fd, &size, LEN_FLD_SIZE)) == -1 && errno == EINTR)
+    {
+        continue;
+    }
 
-	if (result == -1)
-	{
-		die_sys("write() failed");
-	}
+    if (result == -1)
+    {
+        die_sys("write() failed");
+    }
 
-	if (result != LEN_FLD_SIZE)
-	{
-		printf("short write: expected %d bytes, got %zd bytes\n", LEN_FLD_SIZE, result);
-		exit(1);
-	}
+    if (result != LEN_FLD_SIZE)
+    {
+        printf("short write: expected %d bytes, got %zd bytes\n", LEN_FLD_SIZE, result);
+        exit(1);
+    }
 
-	int32_t status;
+    int32_t status;
 
-	while ((result = read(st_fd, &status, LEN_FLD_SIZE)) == -1 && errno == EINTR)
-	{
-		continue;
-	}
+    while ((result = read(st_fd, &status, LEN_FLD_SIZE)) == -1 && errno == EINTR)
+    {
+        continue;
+    }
 
-	memcpy(extra_counters, trace_bits, MAP_SIZE);
+    memcpy(extra_counters, trace_bits, MAP_SIZE);
 
-	if (result == -1)
-	{
-		die_sys("read() failed");
-	}
+    if (result == -1)
+    {
+        die_sys("read() failed");
+    }
 
-	if (result == 0)
-	{
-		die("The child process terminated unexpectedly.");
-	}
+    if (result == 0)
+    {
+        die("The child process terminated unexpectedly.");
+    }
 
-	if (result != LEN_FLD_SIZE)
-	{
-		printf("short read: expected %d bytes, got %zd bytes\n", LEN_FLD_SIZE, result);
-		exit(1);
-	}
+    if (result != LEN_FLD_SIZE)
+    {
+        printf("short read: expected %d bytes, got %zd bytes\n", LEN_FLD_SIZE, result);
+        exit(1);
+    }
 
-	if (status)
-	{
-		__builtin_trap();
-	}
+    if (status)
+    {
+        __builtin_trap();
+    }
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
To make future dev and PRs easier (without minimal PR noise), I propose adopting `clang-format` for code formatting. Right now, this makes _both_ the Linux and Windows harness impls use spaces (instead of tabs, used only on Linux), preserving the existing (common) brace style.