### PR TITLE
Fix job object assignment

### DIFF
--- a/libfuzzer-dotnet-windows.cc
+++ b/libfuzzer-dotnet-windows.cc
@@ -208,6 +208,8 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int *argc, char ***argv)
         die_sys("failed to set `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`");
     }
 
+    // Assign the current process to the job. Later calls to `CreateProcess()` will automatically
+    // assign the created child processes to the job object.
     if (!AssignProcessToJobObject(job, GetCurrentProcess()))
     {
         die_sys("failed to assign `libfuzzer-dotnet` process to job");

--- a/libfuzzer-dotnet-windows.cc
+++ b/libfuzzer-dotnet-windows.cc
@@ -203,6 +203,11 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int *argc, char ***argv)
         die_sys("failed to set `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`");
     }
 
+    if (!AssignProcessToJobObject(job, GetCurrentProcess()))
+    {
+        die_sys("failed to assign `libfuzzer-dotnet` process to job");
+    }
+
     if (target_arg)
     {
         char *temp_target = new char[strlen(target_path) + strlen(target_arg) + 1];

--- a/libfuzzer-dotnet-windows.cc
+++ b/libfuzzer-dotnet-windows.cc
@@ -182,10 +182,15 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int *argc, char ***argv)
     //
     // Since this process will hold the only job handle, the target child process
     // will be terminated even on abnormal exit of the parent harness.
+
+    // Disable child inheritance of the job handle. This ensures that the current process
+    // holds the _only_ handle, so on exit, all job processes will be killed.
+    BOOL inherit_job_handle = FALSE;
+
     SECURITY_ATTRIBUTES job_attrs = {
         sizeof(SECURITY_ATTRIBUTES),
         NULL,
-        FALSE, // Don't inherit job handle
+        inherit_job_handle,
     };
     HANDLE job = CreateJobObjectA(&job_attrs, NULL);
 

--- a/libfuzzer-dotnet-windows.cc
+++ b/libfuzzer-dotnet-windows.cc
@@ -185,7 +185,7 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int *argc, char ***argv)
     SECURITY_ATTRIBUTES job_attrs = {
         sizeof(SECURITY_ATTRIBUTES),
         NULL,
-        TRUE, // Inherit job handle
+        FALSE, // Don't inherit job handle
     };
     HANDLE job = CreateJobObjectA(&job_attrs, NULL);
 


### PR DESCRIPTION
The job object usage in #7 was incomplete.

Previous (somewhat indirect) local testing misled me on the initial PR. This time, validated by observing job assignments in Process Explorer while stepping through execution in WinDbg. Doing this, I can see that both `libfuzzer-dotnet.exe` and the `--target_path` managed process get assigned to a common job object, as expected, and that `Kill on Job Close` is `True`. Then, in my indirect local test, I can see that `libfuzzer-dotnet` exits first, with the target blocked on IO, but that the parent exit results in the target child being terminated automatically (as desired).