### PR TITLE
Bump Clang to v18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
           dotnet-version: ${{ env.dotnet-version }}
       - name: Run libFuzzer tests
         run: cp libfuzzer-dotnet-windows.exe libfuzzer-dotnet.exe && .\test.ps1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: libfuzzer-dotnet
+          name: libfuzzer-dotnet-windows
           path: libfuzzer-dotnet-windows.exe
 
   build-ubuntu:
@@ -40,9 +40,9 @@ jobs:
       - name: Run libFuzzer tests
         shell: pwsh
         run: cp libfuzzer-dotnet-ubuntu libfuzzer-dotnet && .\test.ps1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: libfuzzer-dotnet
+          name: libfuzzer-dotnet-ubuntu
           path: libfuzzer-dotnet-ubuntu
 
   build-debian:
@@ -59,7 +59,7 @@ jobs:
           apt-get update && apt-get install -y clang-18 libfuzzer-18-dev llvm-18 llvm-18-dev
       - name: Build
         run: clang++-18 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-debian
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: libfuzzer-dotnet
+          name: libfuzzer-dotnet-debian
           path: libfuzzer-dotnet-debian

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           path: libfuzzer-dotnet-windows.exe
 
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
           path: libfuzzer-dotnet-ubuntu
 
   build-debian:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: debian:bullseye
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: clang -Werror -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}
       - name: Run libFuzzer tests
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: clang -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-ubuntu
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}
       - name: Run libFuzzer tests
@@ -50,7 +50,7 @@ jobs:
     container: debian:bullseye
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download LLVM
         run: |
           apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,11 @@ jobs:
       - name: Download LLVM
         run: |
           apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg
-          add-apt-repository 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-16 main'
+          add-apt-repository 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-18 main'
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          apt-get update && apt-get install -y clang-16 libfuzzer-16-dev llvm-16 llvm-16-dev
+          apt-get update && apt-get install -y clang-18 libfuzzer-18-dev llvm-18 llvm-18-dev
       - name: Build
-        run: clang++-16 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-debian
+        run: clang++-18 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-debian
       - uses: actions/upload-artifact@v3
         with:
           name: libfuzzer-dotnet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
           git tag -a $tag -m $tag ${{ github.sha }}
           git push origin $tag
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           files: |
             libfuzzer-dotnet-windows.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,20 +20,21 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          name: libfuzzer-dotnet
+          pattern: libfuzzer-dotnet-*
+          merge-multiple: true
       - name: Tag
         id: tag
         run: |
           $tag = "v" + (Get-Date).ToString("yyyy.MM.dd.HHmm")
           Add-Content -Path $env:GITHUB_OUTPUT -Value "tag=$tag"
 
-          git config user.name "${GITHUB_REPOSITORY_OWNER}"
-          git config user.email "${GITHUB_REPOSITORY_OWNER}@users.noreply.github.com"
+          git config user.name "${{ github.repository_owner }}"
+          git config user.email "${{ github.repository_owner }}@users.noreply.github.com"
 
-          git tag -a $tag -m $tag ${GITHUB_SHA}
+          git tag -a $tag -m $tag ${{ github.sha }}
           git push origin $tag
       - uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
With `ubuntu-24.04` [now available](https://github.com/actions/runner-images/issues/9848#issuecomment-2229276124) we can build libfuzzer-dotnet from Clang 18 for all three targets.
If we want to keep using `ubuntu-latest` my guess is that is will be updated later in August to point at `ubuntu-24.04`.

If it's desirable, we could also bump Debian from Bullseye to Bookworm.

This fixes #15 (which also contains git logs for fuzzer related commits to Clang)

I ran the actions on [my fork](https://github.com/jnyrup/libfuzzer-dotnet/actions/runs/9920636946)